### PR TITLE
Design updates

### DIFF
--- a/develop/develop/settings.py
+++ b/develop/develop/settings.py
@@ -123,6 +123,8 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 
+LOGIN_REDIRECT_URL = "/support/"
+
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/
 

--- a/develop/templates/core/index.html
+++ b/develop/templates/core/index.html
@@ -1,5 +1,5 @@
 {% extends "helpme/base.html" %}
 
 {% block content %}
-<a href="{% url 'helpme:dashboard' %}">Go to dashboard</a>
+<a href="{% url 'helpme:submit-request' %}">Make Request</a>
 {% endblock %}

--- a/develop/templates/core/index.html
+++ b/develop/templates/core/index.html
@@ -1,5 +1,5 @@
 {% extends "helpme/base.html" %}
 
 {% block content %}
-<a href="{% url 'helpme:submit-request' %}">Make Request</a>
+<a href="{% url 'helpme:dashboard' %}">Go to dashboard</a>
 {% endblock %}

--- a/helpme/api/serializers.py
+++ b/helpme/api/serializers.py
@@ -6,8 +6,14 @@
 
 from rest_framework import serializers
 
-from helpme.models import Comment, Category, Question
+from helpme.models import Ticket, Comment, Category, Question
 
+
+class TicketSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Ticket
+        fields = ('category', 'subject', 'description')
+        
 
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:

--- a/helpme/api/urls.py
+++ b/helpme/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from helpme.api import views
 
 urlpatterns = [
+    path('ticket/', views.CreateTicketAPIView.as_view(), name='helpme-api-create-ticket'),
     path('<uuid:uuid>/comment/', views.CreateCommentAPIView.as_view(), name='helpme-api-create-comment'),
     path('category/', views.CreateCategoryAPIView.as_view(), name='helpme-api-create-category'),
     path('question/', views.CreateQuestionAPIView.as_view(), name='helpme-api-create-question'),

--- a/helpme/forms.py
+++ b/helpme/forms.py
@@ -1,12 +1,21 @@
 from django.forms import ModelForm
 from django import forms
 from django.utils.translation import gettext as _
+from django.contrib.sites.models import Site
 
-from helpme.models import Comment, Category, Question
+from helpme.models import Ticket, Comment, Category, Question, VisibilityChoices
+
+
+class TicketForm(ModelForm):
+
+    class Meta:
+        model = Ticket
+        fields = ['category', 'subject', 'description']
 
 
 class CommentForm(ModelForm):
-    content = forms.CharField(label="", widget=forms.Textarea(attrs={'placeholder': 'Leave a comment'}))
+    content = forms.CharField(label=_("Message"), widget=forms.Textarea(attrs={'placeholder': 'Enter a message', 'rows': '4'}))
+    visibility = forms.ChoiceField(label=_("Visibility (Who can see this message)"), choices=VisibilityChoices.choices)
     
     class Meta:
         model = Comment
@@ -44,3 +53,7 @@ class QuestionForm(ModelForm):
             self.fields.pop('sites')
             self.fields.pop('global_question')
             self.fields.pop('excluded_sites')
+
+            # limit the possible categories to the current site
+            current_site = Site.objects.get_current()
+            self.fields['category'].queryset = Category.objects.filter(sites__in=[current_site])

--- a/helpme/models.py
+++ b/helpme/models.py
@@ -119,7 +119,7 @@ class Ticket(CreateUpdateModelBase):
     def __str__(self):
         return "{0} - {1}".format(self.user.username, self.subject)
 
-    def log_history_event(self, action, user=None, notes=None, time=None):
+    def log_history_event(self, action, user=None, notes=None, isotime=None):
         '''
         "history": [
             {
@@ -128,10 +128,10 @@ class Ticket(CreateUpdateModelBase):
             }
         ],
         '''
-        if not time:
-            time = timezone.now().strftime("%b %d, %Y, %I:%M %p")
+        if not isotime:
+            isotime = timezone.now().isoformat()           # '2019-12-18T22:27:28.222000+00:00'
 
-        event = {'action':action, 'time':time}
+        event = {'action':action, 'time':isotime}
 
         if user:
             event['user'] = user.pk

--- a/helpme/models.py
+++ b/helpme/models.py
@@ -101,7 +101,7 @@ class Ticket(CreateUpdateModelBase):
     category = models.IntegerField(_("Category"), choices=app_settings.TICKET_CATEGORIES.choices)
     teams = models.ManyToManyField(Team, blank=True, related_name="support_tickets")
     subject = models.CharField(_("Subject"), max_length=120)
-    description = models.TextField(_("Description"))
+    description = models.TextField(_("Message"))
     history = models.JSONField(blank=True, null=True, default=list)
     assigned_to = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.SET_NULL, related_name="assigned_tickets")
     dev_ticket = models.CharField(max_length=30, blank=True, null=True)
@@ -119,19 +119,19 @@ class Ticket(CreateUpdateModelBase):
     def __str__(self):
         return "{0} - {1}".format(self.user.username, self.subject)
 
-    def log_history_event(self, event, user=None, notes=None, isotime=None):
+    def log_history_event(self, action, user=None, notes=None, time=None):
         '''
         "history": [
             {
                 "time": "2020-04-08T23:45:02.225609+00:00",
-                "event": "created"
+                "action": "created"
             }
         ],
         '''
-        if not isotime:
-            isotime = timezone.now().isoformat()           # '2019-12-18T22:27:28.222000+00:00'
+        if not time:
+            time = timezone.now().strftime("%b %d, %Y, %I:%M %p")
 
-        event = {'event':event, 'time':isotime}
+        event = {'action':action, 'time':time}
 
         if user:
             event['user'] = user.pk

--- a/helpme/static/css/support/base.css
+++ b/helpme/static/css/support/base.css
@@ -24,3 +24,9 @@
 .clear-all {
     color: var(--primary);
 }
+
+a.question:hover {
+    font-weight:bold;
+}
+
+

--- a/helpme/templates/helpme/faq.html
+++ b/helpme/templates/helpme/faq.html
@@ -3,81 +3,107 @@
 
 {% block help_content %}
 
-<div class="row">
-  <h1> HELP DESK </h1>
-</div>
-<div class="row">
-  <a href="{% url 'helpme:faq' %}" class="mr-3">
-    <h3 class="text-secondary">
-      <u> FAQ </u>
-    </h3>
-  </a>
-  <a href="{% url 'helpme:dashboard' %}" class="ml-3">
-    <h3>ASK THE HELP DESK</h3>
-  </a>
-</div>
-<div class="row">
-  <ul class="my-3">
+<div class="container-fluid">
+  <div class="row no-gutters">
+    <h1> HELP DESK </h1>
+  </div>
+  <div class="row no-gutters">
+    <a href="{% url 'helpme:faq' %}" class="mr-3">
+      <h5 class="text-secondary">
+	<u> FAQ </u>
+      </h5>
+    </a>
+    <a href="{% url 'helpme:dashboard' %}" class="ml-3">
+      <h5>ASK THE HELP DESK</h5>
+    </a>
+  </div>
+
+  <div class="row">
     {% for category in categories %}
-    <h3> {{ category }} </h3>
-    {% for question in category.questions.all %}
-    <li>
+    <div class="col-sm-4 my-3">
+      <h5>
+	<b>
+	  {{ category }}
+	</b>
+      </h5>
+      {% for question in category.questions.all %}
       <p>
-	<a data-toggle="collapse" href="#answer-{{question.pk}}">
+	<a class="question" data-toggle="collapse" href="#answer-{{question.pk}}">
 	  {{ question.question }}
 	</a>
       </p>
       <p class="collapse" id="answer-{{question.pk}}">
 	{{ question.answer }}
       </p>
-    </li>
-    {% empty %}
-    <li> There are no Frequently Asked Questions in this category yet. </li>
-    {% endfor %}
+      {% empty %}
+      There are no Frequently Asked Questions in this category yet.
+      {% endfor %}
+    </div>
     {% empty %}
     {% for question in questions %}
-    <li>
-      <p>
-	<a data-toggle="collapse" href="#answer-{{question.pk}}">
-	  {{ question.question }}
-	</a>
-      </p>
-      <p class="collapse" id="answer-{{question.pk}}">
-	{{ question.answer }}
-      </p>
-    </li>
+    <p>
+      <a class="question" data-toggle="collapse" href="#answer-{{question.pk}}">
+	{{ question.question }}
+      </a>
+    </p>
+    <p class="collapse" id="answer-{{question.pk}}">
+      {{ question.answer }}
+    </p>
     {% empty %}
-    <li> There are no Frequently Asked Questions yet. </li>
+    There are no Frequently Asked Questions yet.
     {% endfor %}
     {% endfor %}
-  </ul>
-</div>
+  </div>
 
-{% if admin %}
-<div class="mt-3">
-  <h3> Create a New Question </h3>
-  <div class="row">
-    <div class="col-sm">
-      <form method="post" action="{% url 'helpme-api-create-question' %}">
-        {% csrf_token %}
-        {{ question_form|crispy }}
-        <input type="submit" value="Create" class="btn btn-success">
-      </form>
+  {% if admin %}
+  <div class="mt-3">
+    <h3> Create a New Question </h3>
+    <div class="row">
+      <div class="col-sm">
+	<form method="post" action="{% url 'helpme-api-create-question' %}">
+          {% csrf_token %}
+          {{ question_form|crispy }}
+          <input type="submit" value="Create" class="btn btn-success">
+	</form>
+      </div>
     </div>
   </div>
-</div>
-<div class="mt-3">
-  <h3> Create a New Category </h3>
-  <div class="row">
-    <div class="col-sm">
-      <form method="post" action="{% url 'helpme-api-create-category' %}">
-        {% csrf_token %}
-        {{ category_form|crispy }}
-        <input type="submit" value="Create" class="btn btn-success">
-      </form>
+  <div class="mt-3">
+    <h3> Create a New Category </h3>
+    <div class="row">
+      <div class="col-sm">
+	<form method="post" action="{% url 'helpme-api-create-category' %}">
+          {% csrf_token %}
+          {{ category_form|crispy }}
+          <input type="submit" value="Create" class="btn btn-success">
+	</form>
+      </div>
     </div>
   </div>
+  {% endif %}
+  
 </div>
-{% endif %}
+{% endblock %}
+  
+{% block extra_js %}
+<!-- A question becomes bold when selected -->
+<script>
+  var questions = document.getElementsByClassName('question');
+  var num = questions.length;
+  
+  function toggleBold(e) {
+    var question = $(e.currentTarget)[0];
+  
+    if (question.style.fontWeight === "bold") {
+      question.style.fontWeight = ""
+    }
+    else {
+      question.style.fontWeight = "bold"
+    }
+  }
 
+  for (var i = 0; i < num; i++) {
+    questions[i].addEventListener('click', toggleBold, false)
+  };
+</script>
 {% endblock %}

--- a/helpme/templates/helpme/ticket_detail.html
+++ b/helpme/templates/helpme/ticket_detail.html
@@ -141,8 +141,7 @@
             <tr>
               <td>{{ item.action }}</td>
               <td>{{ item.username }}</td>
-              {% convert_isotime item.time as datetime %}
-              <td>{{ datetime|date:"M j, Y, g:i a" }}</td> 
+              <td>{{ item.time|convert_isotime|date:"M j, Y, g:i a" }}</td> 
             </tr>
             {% endfor %}
           </tbody>

--- a/helpme/templates/helpme/ticket_detail.html
+++ b/helpme/templates/helpme/ticket_detail.html
@@ -1,187 +1,198 @@
 {% extends "helpme/base.html" %}
 {% load crispy_forms_tags %}
+{% load helpme_extras %}
 
 {% block help_content %}
 
-      <div class="row">
-        <div class="col-9">
-          <h2>{{ticket.subject}}</h2>
-        </div>
-        <div class="col-3 text-right">
-          <h4><small>Status:</small> <span class="badge badge-pill badge-primary">{{ ticket.get_status_display }}</span></h4>
-        </div>
+<div class="container-fluid mt-3">
+  <div class="row align-items-end">
+    <div class="col">
+      <h3 class="mt-3">
+	<b> {{ ticket.subject }} </b>
+      </h3>
+      <div class="text-secondary">
+	Status: 
+	{% if ticket.status in negative_status %}
+	<span class="text-danger mr-2">
+	{% else %}
+	<span class="text-success mr-2">
+	{% endif %}
+	  <b>
+	    {{ticket.get_status_display}}
+	  </b>
+	</span>
+	Priority:
+	<b>
+	  {{ ticket.get_priority_display }}
+	</b>
       </div>
-
-{% if support %}
-
-<ul class="nav nav-tabs" id="myTab" role="tablist">
-  <li class="nav-item" role="presentation">
-    <a class="nav-link active" id="home-tab" data-toggle="tab" href="#comment" role="tab" aria-controls="comment" aria-selected="true">Comments</a>
-  </li>
-  <li class="nav-item" role="presentation">
-    <a class="nav-link" id="profile-tab" data-toggle="tab" href="#detail" role="tab" aria-controls="detail" aria-selected="false">Details</a>
-  </li>
-  <li class="nav-item" role="presentation">
-    <a class="nav-link" id="contact-tab" data-toggle="tab" href="#edit" role="tab" aria-controls="edit" aria-selected="false">Edit</a>
-  </li>
-</ul>
-
-<div class="tab-content" id="myTabContent">
-  <div class="tab-pane fade show active" id="comment" role="tabpanel" aria-labelledby="comment-tab">
-    <div class="mt-3">
-  
-      <div class="row">
-        <div class="col-10">
-          <div class="alert alert-secondary" role="alert">
-            <p>{{ ticket.description }}</p>  
-          </div>
-        </div>
-        <div class="col-2">
-          <p><b>{{ ticket.user.username }}</b><br><small>{{ ticket.created }}</small></p>
-        </div>
+      <small class="text-secondary">
+	Created: {{ticket.created}}
+      </small>
+      <div class="text-secondary">
+	Category: <b>{{ ticket.get_category_display }}</b>
       </div>
-
-      {% for comment in comments %}
-      <div class="row">
-        <div class="col-2">
-          <p><b>{{ comment.user.username }}</b><br><small>{{ comment.created }}</small></p>
-        </div>
-        <div class="col-10">
-          <div class="alert alert-primary" role="alert">
-            <p>{{ comment.content  }}</p>  
-          </div>
-        </div>
-      </div>
-      {% endfor %}
-
+      <p class="mt-3"> {{ ticket.description }} </p>
     </div>
-
-    <hr>
-    <h4>Add Comment</h4>
-    <form method="post" action="{% url 'helpme-api-create-comment' ticket.uuid %}" class="text-center">
-        {% csrf_token %}
-        {{ comment_form|crispy }}
-        <input type="submit" value="Comment" class="btn btn-success">
-    </form>
-
+    <div class="col-sm text-center text-sm-right mb-3">
+      <a href="" role="button" data-toggle="modal" data-target="#edit"> Edit Details</a>
+      <button class="btn btn-success ml-3"  data-toggle="modal" data-target="#request">
+	New Help Ticket
+      </button>
+    </div>
   </div>
+</div>
 
-  <div class="tab-pane fade" id="detail" role="tabpanel" aria-labelledby="detail-tab">
-    <div class="mt-3">
+<hr>
 
-      <div class="row">
-        <div class="col-sm">
-          <p>
-              <b>User: </b>
-              {{ticket.user.username}}
-          </p>
-          <p>
-            <b>User Meta: </b>
-            <table class="table table-hover">
-              <thead>
-                <tr>
-                  <th scope="col">attribute</th>
-                  <th scope="col">value</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for key, value in ticket.user_meta.items %}  
-                <tr>
-                    <td>{{key}}:</td>
-                    <td>{{value}}</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </p>
-          <p>
-              <b>Site: </b>
-              {{ticket.site}}
-          </p>
-          <p>
-              <b>Created: </b>
-              {{ticket.created}}
-          </p>
-          <p>
-              <b>Updated: </b>
-              {{ticket.updated}}
-          </p>
-        </div>
-        <div class="col-sm">
-          <p>
-              <b>History: </b>
-          </p>
+<div class="parent-container d-flex">
+  <div class="container" style="width:66%;">
+    {% for comment in ticket.comments.all|sort_by:'-created' %}
+    
+    {% if comment in comments %}
+    {% if comment.user == user %}
+    <div class="row mb-3">
+      <div class="col offset-1">
+	<div class="alert alert-primary mb-0">
+	  {{ comment.content  }}
+	</div>
+	<small>
+	  Visibility: {{ comment.get_visibility_display }}
+	</small>
+	<small class="float-right">
+	  <b>{{ comment.user.username }}</b>
+	  {{ comment.created }}
+	</small>
+    {% else %}
+    <div class="row mb-3">
+      <div class="col-11">
+	<div class="alert alert-secondary mb-0">
+	  {{ comment.content  }}
+	</div>
+	<small>
+	  <b>{{ comment.user.username }}</b>
+	  {{ comment.created }}
+	</small>
+	<small class="float-right">
+	  Visibility: {{ comment.get_visibility_display }}
+	</small>
+    {% endif %}
+      </div>
+    </div>
+    {% endif %}
+
+    {% endfor %}
+    <div class="row">
+      <div class="col">
+	<form action="{% url 'helpme-api-create-comment' ticket.uuid %}" method="POST">
+	  {% csrf_token %}
+	  {{ comment_form|crispy }}
+	  <input type="submit" value="Reply" class="btn btn-primary mr-3">
+	</form>
+      </div>
+    </div>
+  </div>
+  <div class="container" style="width:33%; overflow-y: scroll;">
+    <div class="row">
+      <div class="col-sm">
+        <p>
+          <b>Reporter: </b>
+          {{ticket.user.username}}
+        </p>
+	<p>
+          <b>Reporter Meta: </b>
           <table class="table table-hover">
-            <thead>
-              <tr>
-                <th scope="col">event</th>
-                <th scope="col">user</th>
-                <th scope="col">time</th>
-                <th scope="col">notes</th>
-              </tr>
-            </thead>
+	    <thead>
+	      <th></th>
+	      <th></th>
+	    </thead>
             <tbody>
-              {% for item in ticket.history %}
+              {% for key, value in ticket.user_meta.items %}  
               <tr>
-                <td>{{ item.event }}</td>
-                <td>{{ item.username }}</td>
-                <td>{{ item.time }}</td>
-                <td>{{ item.notes }}</td>
+                <td>{{key}}:</td>
+                <td>{{value}}</td>
               </tr>
               {% endfor %}
             </tbody>
           </table>
-
-        </div>
+        </p>
+        <p>
+          <b>Site: </b>
+          {{ticket.site}}
+        </p>
+        <p>
+          <b>Last Updated: </b>
+          {{ticket.updated}}
+        </p>
+	{% if ticket.history %}
+        <p>
+          <b>Support History: </b>
+        </p>
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th scope="col">Action</th>
+              <th scope="col">User</th>
+              <th scope="col">Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in ticket.history %}
+            <tr>
+              <td>{{ item.action }}</td>
+              <td>{{ item.username }}</td>
+              <td>{{ item.time }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+	{% endif %}
       </div>
     </div>
   </div>
+</div>
 
-  <div class="tab-pane fade" id="edit" role="tabpanel" aria-labelledby="edit-tab">
-    <div class="mt-3">
-      <div class="row">
-        <div class="col-sm">
-          <form method="post">
-              {% csrf_token %}
-              {{ form|crispy }}
-              <input type="submit" value="Update" class="btn btn-success">
-          </form>
-        </div>
+<div class="modal" id="request">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <!-- Modal body -->
+      <div class="modal-body">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+	<h3 class="modal-title mt-3">
+	  <b>New Help Ticket</b>
+	</h3>
+	<p> Please provide clear details about how we can help you. </p>
+        <form action="{% url 'helpme-api-create-ticket' %}" method="POST">
+          {% csrf_token %}
+          {{ ticket_form|crispy }}
+          <input type="submit" value="Create Ticket" class="btn btn-primary mr-3">
+	  <a href="" data-dismiss="modal">Close</a>
+        </form>
+      </div>
+      
+    </div>
+  </div>
+</div>
+
+<div class="modal" id="edit">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <!-- Modal body -->
+      <div class="modal-body">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+	<h3 class="modal-title mt-3">
+	  <b>Edit Ticket Details</b>
+	</h3>
+        <form method="post">
+          {% csrf_token %}
+          {{ form|crispy }}
+          <input type="submit" value="Update" class="btn btn-success">
+        </form>
       </div>
     </div>
   </div>
-
 </div>
-
-{% else %}
-<div class="row">
-  <div class="col-12">
-    <div class="alert alert-secondary" role="alert">
-      <p>{{ ticket.description }}</p>  
-    </div>
-  </div>
-</div>
-<hr>
-{% for comment in comments %}
-<div class="row">
-  <div class="col-2">
-    <p><b>{{ comment.user.username }}</b><br><small>{{ comment.created }}</small></p>
-  </div>
-  <div class="col-10">
-    <div class="alert alert-primary" role="alert">
-      <p>{{ comment.content  }}</p>  
-    </div>
-  </div>
-</div>
-{% endfor %}
-<hr>
-<h2>Add Comment</h2>
-<form method="post" action="{% url 'helpme-api-create-comment' ticket.uuid %}" class="text-center">
-    {% csrf_token %}
-    {{ comment_form|crispy }}
-    <input type="submit" value="Comment" class="btn btn-success">
-</form>
-
-{% endif %}
 
 {% endblock %}

--- a/helpme/templates/helpme/ticket_detail.html
+++ b/helpme/templates/helpme/ticket_detail.html
@@ -141,7 +141,8 @@
             <tr>
               <td>{{ item.action }}</td>
               <td>{{ item.username }}</td>
-              <td>{{ item.time }}</td>
+              {% convert_isotime item.time as datetime %}
+              <td>{{ datetime|date:"M j, Y, g:i a" }}</td> 
             </tr>
             {% endfor %}
           </tbody>

--- a/helpme/templates/helpme/ticket_list.html
+++ b/helpme/templates/helpme/ticket_list.html
@@ -1,21 +1,38 @@
 {% extends "helpme/base.html" %}
+{% load crispy_forms_tags %}
+{% load helpme_extras %}
 
 {% block help_content %}
-<div class="row">
-  <h1> HELP DESK </h1>
+<div class="row no-gutters">
+  <h1>
+    HELP DESK
+  </h1>
 </div>
-<div class="row">
+<div class="row no-gutters">
   <a href="{% url 'helpme:faq' %}" class="mr-3">
-    <h3>FAQ</h3>
+    <h5>
+      FAQ
+    </h5>
   </a>
   <a href="{% url 'helpme:dashboard' %}" class="ml-3">
-    <h3 class="text-secondary">
-      <u>ASK THE HELP DESK</u>
-    </h3>
+    <h5 class="text-secondary">
+      <u>
+	ASK THE HELP DESK
+      </u>
+    </h5>
   </a>
+  {% if support %}
   <div class="col">
+    <form id="pagination_form" action="" method="get" class="form form-inline float-right">
+      <div class="text-right mx-3"> Show: </div>
+      <select class="selectpicker" name="paginate_by" id="paginate_by" data-show-tick="true">
+        <option>10</option>
+        <option>25</option>
+        <option>50</option>
+      </select>
+    </form>
+    
     <div class="filter-wrapper text-right">
-      <div class="d-inline-block font-weight-bold small"> {{object_list.count}} Tickets </div>
       <ul class="d-inline-block ">
         <li>
           <div class="d-inline-block font-weight-bold small">FILTER BY:</div>
@@ -33,39 +50,243 @@
                 <label class="form-check-label" for="check-{{ name }}">{{ name }}</label>
               </div>
               {% endfor %}
-              <div class="dropdown-item"><a class="clear-all small" href="#">Clear All</a></div>
+              <div class="dropdown-item">
+                <a class="clear-all small" href="#">Clear All</a>
+              </div>
             </div>
           </div>
         </li>
       </ul>
     </div>
   </div>
+  
+  {% endif %}
 </div>
-<ul>
-{% for ticket in object_list %}
-    <li>
-        <a href="{% url 'helpme:ticket-detail' ticket.uuid %}">{{ ticket }}</a>
-        <div>
-            <b>Status: </b>
-            {{ticket.get_status_display}}
-        </div>
-        {% if support %}
-        <div>
-            <b>Priority: </b>
-            {{ticket.get_priority_display}}
-        </div>
-        {% endif %}
-    </li>
-{% empty %}
-    <li>You have no tickets yet.</li>
-{% endfor %}
-</ul>
 
-<a class="btn btn-success" href="{% url 'helpme:submit-request' %}">Create a Request</a>
+<div class="row">
+  <div class="col-sm">
+    <h5 class="mt-2">
+      <b>
+	How can we help you today?
+      </b>
+    </h5>
+  </div>
+  <div class="col-sm text-center text-sm-right">
+    <button class="btn btn-success"  data-toggle="modal" data-target="#request">
+      New Help Ticket
+    </button>
+  </div>
+</div>
+
+<div class="modal" id="request">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <!-- Modal body -->
+      <div class="modal-body">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+	<h3 class="modal-title mt-3">
+	  <b>New Help Ticket</b>
+	</h3>
+	<p> Please provide clear details about how we can help you. </p>
+        <form action="{% url 'helpme-api-create-ticket' %}" method="POST">
+            {% csrf_token %}
+            {{ ticket_form|crispy }}
+            <input type="submit" value="Create Ticket" class="btn btn-primary mr-3">
+	    <a href="" data-dismiss="modal">Close</a>
+        </form>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<div class="row mt-3">
+  <div class="col">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>My Help Tickets</th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+	{% for ticket in object_list %}
+        <tr>
+          <td>
+	    <small> Created: {{ ticket.created.date }} </small>
+	    <div class="mt-1">
+	      {% if support %}
+	      <a type="button" href="{% url 'helpme:ticket-detail' ticket.uuid %}">
+	      {{ ticket }}
+	      {% else %}
+	      <a type="button" href="" data-toggle="modal" data-target="#detail-{{ticket.pk}}">
+	      {{ ticket.subject }}
+	      {% endif %}
+	    </a>
+	    </div>
+	  </td>
+          <td class="align-middle">
+	    Status:
+	    {% if ticket.status in negative_status %}
+	    <span class="text-danger">
+	    {% else %}
+	    <span class="text-success">
+	    {% endif %}
+	      <b>
+	        {{ticket.get_status_display}}
+	      </b>
+	    </span>
+	  </td>
+          <td class="align-middle">
+	    {% if ticket.comments.exists %}
+
+	    {% with ticket.comments.all|last_visible:comments as comment %}
+	    {% if comment.user == user %}
+	    You replied {{ comment.created.date }}
+	    {% else %}
+	    {{ comment.user }} replied {{ comment.created.date }}
+	    {% endif %}
+	    {% endwith %}
+	    
+	    {% else %}
+	    Waiting for a reply
+	    {% endif %}
+	  </td>
+        </tr>
+
+	<div class="modal" id="detail-{{ticket.pk}}">
+	  <div class="modal-dialog">
+	    <div class="modal-content">
+
+	      <!-- Modal body -->
+	      <div class="modal-body">
+		<button type="button" class="close" data-dismiss="modal">&times;</button>
+		<h3 class="modal-title mt-3">
+		  <b> {{ ticket.subject }} </b>
+		</h3>
+		<div class="text-secondary">
+		  Status: 
+		  {% if ticket.status in negative_status %}
+		  <span class="text-danger mr-2">
+		  {% else %}
+		  <span class="text-success mr-2">
+		  {% endif %}
+		    <b>
+		      {{ticket.get_status_display}}
+		    </b>
+		  </span>
+		</div>
+		<small class="text-secondary">
+		  Created: {{ticket.created}}
+		</small>
+		<div class="text-secondary">
+		  Category: <b>{{ ticket.get_category_display }}</b>
+		</div>
+		<p class="mt-3"> {{ ticket.description }} </p>
+		
+		<hr>
+		
+		{% for comment in ticket.comments.all|sort_by:'-created' %}
+
+		{% if comment in comments %}
+		{% if comment.user == user %}
+		<div class="row mb-3 justify-content-end">
+		  <div class="col-11">
+		    <div class="alert alert-primary mb-0">
+		      {{ comment.content  }}
+		    </div>
+		    <small class="float-right">
+		      <b>{{ comment.user.username }}</b>
+		      {{ comment.created }}
+		    </small>
+		{% else %}
+		<div class="row mb-3">
+		  <div class="col-11">
+		    <div class="alert alert-secondary mb-0">
+		      {{ comment.content  }}
+		    </div>
+		    <small>
+		      <b>{{ comment.user.username }}</b>
+		      {{ comment.created }}
+		    </small>
+		{% endif %}
+		  </div>
+		</div>
+		{% endif %}
+		
+		{% endfor %}
+		<form id="comment_form" action="{% url 'helpme-api-create-comment' ticket.uuid %}" method="POST" pk="{{ticket.pk}}">
+		  {% csrf_token %}
+		  {{ comment_form|crispy }}
+		  <input type="submit" value="Reply" class="btn btn-primary mr-3">
+		</form>
+	      </div>
+	      
+	    </div>
+	  </div>
+	</div>
+	
+	{% empty %}
+	<tr>
+	  <td> You have no active tickets. </td>
+	  <td></td>
+	  <td></td>
+	</tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    {% if paginator.num_pages > 1 or object_list.count > 1 %}
+    <div>
+      Showing {{ page_obj.start_index }} to {{ page_obj.end_index }} of {% multiply object_list.count paginator.num_pages %} entries
+    </div>
+    <nav aria-label="Support dashboard page navigation">
+      <ul class="pagination float-right mt-3">
+	
+        {% if page_obj.has_previous %}
+        <li class="page-item">
+	  <a class="page-link" href="?{% url_replace request 'page' 1 %}">&laquo; First</a>
+	</li>
+        <li class="page-item">
+	  <a class="page-link" href="?{% url_replace request 'page' page_obj.previous_page_number %}">Previous</a>
+	</li>
+        {% endif %}
+
+	{% if paginator.num_pages > 1 %}
+	{% for i in paginator.page_range %}
+	{% if page_obj.number == i %}
+	<li class="active page-item">
+	  <a class="page-link" href="?{% url_replace request 'page' i %}">{{ i }}</a>
+	</li>
+	{% else %}
+        <li class="page-item">
+	  <a class="page-link" href="?{% url_replace request 'page' i %}">{{ i }}</a>
+	</li>
+	{% endif %}
+	{% endfor %}
+	{% endif %}
+
+        {% if page_obj.has_next %}
+        <li class="page-item">
+	  <a class="page-link" href="?{% url_replace request 'page' page_obj.next_page_number %}">Next</a>
+	</li>
+        <li class="page-item">
+	  <a class="page-link" href="?{% url_replace request 'page' paginator.num_pages %}">Last &raquo;</a>
+	</li>
+        {% endif %}
+      </ul>
+    </nav>
+    {% endif %}
+    
+  </div>
+</div>
 
 {% endblock %}
 
 {% block extra_js %}
+    <!-- filter tickets by status -->
     <script>
         var statuses = [];
 
@@ -87,8 +308,12 @@
         function reloadPage() {
             var query = getUrlVars();
             query['s'] = statuses.join(',');
+	    if (query['page']) {
+	       query['page'] = 1;
+	    };
             var queryString = $.param(query);
-            var url = window.location.origin + window.location.pathname + '?' + queryString;
+            var url = window.location.origin + window.location.pathname + '?' + queryString
+	;
             window.location = url;
         }
 
@@ -123,5 +348,65 @@
             return vars;
         }
 
+    </script>
+
+    <!-- change pagination -->
+    <script>
+      $(document).ready(function() {
+      var select_pickers = document.querySelectorAll('.selectpicker');
+
+      select_pickers.forEach(function(el) {
+            var el_form = el.closest('form');
+            el.addEventListener('change', function(evt) {
+                el_form.submit();
+            });
+        });
+      
+      const params = new URLSearchParams(window.location.search)
+        $('#paginate_by option').each((idx, option) => {
+            if (option.value === params.get('paginate_by')) {
+                option.selected = true;
+            }
+        })
+	});
+    </script>
+    
+    <!-- refresh the modal if the correct variables are set -->
+    <script>
+      function reloadNow(pk){
+        sessionStorage.setItem('refreshModal',"true");
+        sessionStorage.setItem('ticket', pk);
+        window.location.reload(true);
+      }
+
+      //when loading:        
+      if (sessionStorage.getItem('refreshModal') === "true") {
+        $("#detail-" + sessionStorage.getItem('ticket')).modal("toggle");
+        sessionStorage.clear(); //so it doesn't trigger next time
+        
+      }
+    </script>
+
+    <!-- submit comment form via ajax and call function to refresh the modal -->
+    <script>
+      $(document).on('submit', '#comment_form',function(e){
+      e.preventDefault();
+      var pk = $(this).attr("pk");
+    $.ajax({
+        type:'POST',
+        url:$(this).attr("action"),
+        data:{
+            content:$('#id_content').val(),
+            csrfmiddlewaretoken:$('input[name=csrfmiddlewaretoken]').val(),
+            action: 'post'
+        },
+        success:function(json){
+            reloadNow(pk);   
+        },
+        error : function(xhr,errmsg,err) {
+        console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
+    }
+    });
+});
     </script>
 {% endblock %}

--- a/helpme/templates/helpme/ticket_list.html
+++ b/helpme/templates/helpme/ticket_list.html
@@ -312,8 +312,7 @@
 	       query['page'] = 1;
 	    };
             var queryString = $.param(query);
-            var url = window.location.origin + window.location.pathname + '?' + queryString
-	;
+            var url = window.location.origin + window.location.pathname + '?' + queryString;
             window.location = url;
         }
 

--- a/helpme/templatetags/helpme_extras.py
+++ b/helpme/templatetags/helpme_extras.py
@@ -17,7 +17,7 @@ def last_visible(ticket_comments, comments):
             break
     return last_visible
 
-@register.simple_tag
+@register.filter
 def convert_isotime(isotime):
     return datetime.strptime(isotime[:19], '%Y-%m-%dT%H:%M:%S')
 

--- a/helpme/templatetags/helpme_extras.py
+++ b/helpme/templatetags/helpme_extras.py
@@ -1,0 +1,31 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def sort_by(queryset, order):
+    return queryset.order_by(order)
+
+# find the ticket's last comment visible to the current user
+@register.filter
+def last_visible(ticket_comments, comments):
+    last_visible = None
+    for comment in ticket_comments.order_by('-created'):
+        if comment in comments:
+            last_visible = comment
+            break
+    return last_visible
+
+@register.simple_tag
+def url_replace(request, field, value):
+
+    dict_ = request.GET.copy()
+
+    dict_[field] = value
+
+    return dict_.urlencode()
+
+@register.simple_tag
+def multiply(a, b):
+    return a * b
+

--- a/helpme/templatetags/helpme_extras.py
+++ b/helpme/templatetags/helpme_extras.py
@@ -1,4 +1,5 @@
 from django import template
+from datetime import datetime
 
 register = template.Library()
 
@@ -15,6 +16,10 @@ def last_visible(ticket_comments, comments):
             last_visible = comment
             break
     return last_visible
+
+@register.simple_tag
+def convert_isotime(isotime):
+    return datetime.strptime(isotime[:19], '%Y-%m-%dT%H:%M:%S')
 
 @register.simple_tag
 def url_replace(request, field, value):

--- a/helpme/urls.py
+++ b/helpme/urls.py
@@ -7,7 +7,6 @@ app_name = "helpme"
 urlpatterns = [
     path("", views.SupportDashboardView.as_view(), name="dashboard"),
     path("faq/", views.FAQView.as_view(), name="faq"),
-    path("request/", views.SupportRequestView.as_view(), name="submit-request"),
     path("ticket/<uuid:uuid>/", views.TicketDetailView.as_view(), name="ticket-detail"),
     path("teams/", views.TeamCreateView.as_view(), name="team-list"),
     path("teams/<uuid:uuid>/", views.TeamDetailView.as_view(), name="team-detail"),

--- a/helpme/urls.py
+++ b/helpme/urls.py
@@ -7,6 +7,7 @@ app_name = "helpme"
 urlpatterns = [
     path("", views.SupportDashboardView.as_view(), name="dashboard"),
     path("faq/", views.FAQView.as_view(), name="faq"),
+    path("request/", views.SupportRequestView.as_view(), name="submit-request"),
     path("ticket/<uuid:uuid>/", views.TicketDetailView.as_view(), name="ticket-detail"),
     path("teams/", views.TeamCreateView.as_view(), name="team-list"),
     path("teams/<uuid:uuid>/", views.TeamDetailView.as_view(), name="team-detail"),

--- a/helpme/views.py
+++ b/helpme/views.py
@@ -103,7 +103,7 @@ class SupportDashboardView(LoginRequiredMixin, ListView):
             # exclude closed tickets by default
             queryset = queryset.exclude(status=StatusChoices.CLOSED)
             
-        return queryset.order_by('-priority')
+        return queryset.distinct().order_by('-priority')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
- Design updates to the FAQ, Support Dashboard, and Ticket Detail views
- Ticket creation can now be done from the dashboard or ticket detail view, via modal
- Regular users will see their ticket details/message history in a modal as well
- Removed tabs from the support Ticket Detail view, combining the comments and details into one page and shifting the editing to a modal