### PR TITLE
Teams updates

### DIFF
--- a/helpme/__version__.py
+++ b/helpme/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.9"
+VERSION = "0.1.11"

--- a/helpme/forms.py
+++ b/helpme/forms.py
@@ -90,8 +90,6 @@ class QuestionForm(ModelForm):
 
 
 class TeamForm(ModelForm):
-    sites = forms.ModelMultipleChoiceField(queryset=Site.objects.all(), widget=forms.CheckboxSelectMultiple)
-    
     # get users with explicit support permissions
     # as well as admins with all permissions
     member_qs = get_user_model().objects.filter(user_permissions__codename="see-support-tickets") | get_user_model().objects.filter(is_superuser=True)
@@ -99,11 +97,4 @@ class TeamForm(ModelForm):
 
     class Meta:
         model = Team
-        fields = ['name', 'global_team', 'sites', 'categories', 'members']
-
-    def __init__(self, staff=False, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields['global_team'].label = _("Global team? (Provides support for all sites)")
-        if not staff:
-            self.fields.pop('sites')
-            self.fields.pop('global_team')
+        fields = ['name', 'categories', 'members']

--- a/helpme/templates/helpme/team_detail.html
+++ b/helpme/templates/helpme/team_detail.html
@@ -9,6 +9,16 @@
     {{ form|crispy }}
     <input type="submit" value="Update" class="btn btn-primary font-weight-bold py-2 px-4 mt-3 rounded-pill">
 </form>
+<p>
+    <b>Handles Site(s): </b>
+    <ul class="list-group">
+	{% for site in team.sites.all %}
+	<li class="list-group-item">
+	    {{ site }}
+	</li>
+	{% endfor %}
+    </ul>
+</p>
 {% else %}
 <h1 class="my-2">{{team.name}}</h1>
 <p>

--- a/helpme/views.py
+++ b/helpme/views.py
@@ -223,26 +223,13 @@ class TeamCreateView(LoginRequiredMixin, PermissionRequiredMixin, CreateView):
         context = super().get_context_data(**kwargs)
         context['admin'] = self.request.user.has_perm('helpme.add_team')
         context['user_teams'] = self.request.user.team_set.all()
-        if self.request.user.is_staff:
-            context['teams'] = Team.objects.all()
-        else:
-            context['teams'] = Team.objects.filter(sites__in=[Site.objects.get_current()])
+        context['teams'] = Team.objects.filter(sites__in=[Site.objects.get_current()])
         return context
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs.update({'staff':self.request.user.is_staff})
-        return kwargs
+    
 
     def form_valid(self, form):
         response = super().form_valid(form)
-
-        if form.instance.global_team:
-            form.instance.sites.set(Site.objects.all())
-        elif form.instance.sites.exists():
-            form.instance.sites.set(form.instance.sites.all())
-        else:
-            form.instance.sites.add(Site.objects.get_current())
+        form.instance.sites.add(Site.objects.get_current())
         return response
     
     
@@ -268,16 +255,6 @@ class TeamDetailView(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
                           {'verbose_name': queryset.model._meta.verbose_name})
         return obj
 
-    def form_valid(self, form):
-        response = super().form_valid(form)
-        if form.instance.global_team:
-            form.instance.sites.set(Site.objects.all())
-        return response
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs.update({'staff':self.request.user.is_staff})
-        return kwargs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
- Remove sites and global_team fields from Teams form; this should be done in the admin panel, for greater security
- Automatically assign Team to the current site
- On the Teams page, show Teams based on the current site
- Version bump