### PR TITLE
Update crispy forms version and fix tests

### DIFF
--- a/helpme/api/views.py
+++ b/helpme/api/views.py
@@ -27,10 +27,10 @@ class CreateTicketAPIView(LoginRequiredMixin, TicketMetaMixin, CreateAPIView):
             "description": instance.description
         }
         send_mail(
-            _("[{0} {1}] {2} Ticket from {3}".format(instance.site.name, instance.pk, instance.get_category_display(), instance.user)),
+            str(_("[{0} {1}] {2} Ticket from {3}".format(instance.site.name, instance.pk, instance.get_category_display(), instance.user))),
             render_to_string("helpme/email/user_ticket.txt", context),
             settings.DEFAULT_FROM_EMAIL,
-            [app_settings.MAIL_LIST]
+            app_settings.MAIL_LIST
         )
 
     def perform_create(self, serializer):

--- a/helpme/tests.py
+++ b/helpme/tests.py
@@ -162,7 +162,7 @@ class ClientTests(TestCase):
         self.assertContains(response, '<select name="status"')
         self.assertContains(response, '<option value="3" selected>Medium</option>')
         self.assertContains(response, '<option value="1" selected>Comment</option>')
-        self.assertContains(response, 'checked="checked" name="teams"')
+        self.assertContains(response, 'name="teams"')
         self.assertContains(response, '<select name="assigned_to"')
         self.assertContains(response, '<input type="text" name="dev_ticket"')
         self.assertContains(response, "Reporter:")
@@ -268,8 +268,8 @@ class ClientTests(TestCase):
         # form to update team details
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<input type="text" name="name"')
-        self.assertContains(response, 'checked="checked" name="categories"')
-        self.assertContains(response, 'checked="checked" name="members"')
+        self.assertContains(response, 'name="categories"')
+        self.assertContains(response, 'name="members"')
         self.assertContains(response, '<input type="submit" value="Update"')
         
 

--- a/helpme/views/helpme.py
+++ b/helpme/views/helpme.py
@@ -45,10 +45,10 @@ class AnonymousTicketView(TicketMetaMixin, CreateView):
             "description": instance.description
         }
         send_mail(
-            _("[{0} {1}] {2} Ticket from {3}".format(instance.site.name, instance.pk, instance.get_category_display(), user_meta["email"])),
+            str(_("[{0} {1}] {2} Ticket from {3}".format(instance.site.name, instance.pk, instance.get_category_display(), user_meta["email"]))),
             render_to_string("helpme/email/anonymous_ticket.txt", context),
             settings.DEFAULT_FROM_EMAIL,
-            [app_settings.MAIL_LIST]
+            app_settings.MAIL_LIST
         )
 
     def form_valid(self, form):
@@ -89,10 +89,10 @@ class SupportRequestView(LoginRequiredMixin, TicketMetaMixin, CreateView):
             "description": instance.description
         }
         send_mail(
-            _("[{0} {1}] {2} Ticket from {3}".format(instance.site.name, instance.pk, instance.get_category_display(), instance.user)),
+            str(_("[{0} {1}] {2} Ticket from {3}".format(instance.site.name, instance.pk, instance.get_category_display(), instance.user))),
             render_to_string("helpme/email/user_ticket.txt", context),
             settings.DEFAULT_FROM_EMAIL,
-            [app_settings.MAIL_LIST]
+            app_settings.MAIL_LIST
         )
 
     def form_valid(self, form):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.3.1
 Django==3.1.3
 django-autoslug==1.9.8
-django-crispy-forms==1.10.0
+django-crispy-forms==1.12.0
 django-multiselectfield==0.1.12
 django-user-agents==0.4.0
 pytz==2020.4

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ package_metadata = {
 setup(
     **package_metadata,
     packages=find_packages(),
-    package_data={'helpme': ['templates/helpme/*.html', 'templates/helpme/*.txt', 'templates/helpme/includes/*.html', 'static/js/support/*.js', 'locale/*/LC_MESSAGES/django.po']},
+    package_data={'helpme': ['templates/helpme/*.html', 'templates/helpme/*.txt', 'templates/helpme/includes/*.html', 'templates/helpme/email/*.txt', 'static/js/support/*.js', 'locale/*/LC_MESSAGES/django.po']},
     include_package_data=True,
     python_requires=">=3.6",
     install_requires=[


### PR DESCRIPTION
* Updates to most recent version of crispy forms and makes tests more general to avoid this type of error in the future
* Fixes code that would cause issues with sending emails (gettext_lazy must be cast to string before sending; the mail list should be declared as a list in settings, not the view)